### PR TITLE
Add retry delay to ip address lookup

### DIFF
--- a/src/Aquifer.Common/Clients/Http/IpAddressLookup/IpAddressLookupHttpClient.cs
+++ b/src/Aquifer.Common/Clients/Http/IpAddressLookup/IpAddressLookupHttpClient.cs
@@ -1,5 +1,6 @@
 ﻿using Aquifer.Common.Utilities;
 using Microsoft.Extensions.Logging;
+using System.Net;
 
 namespace Aquifer.Common.Clients.Http.IpAddressLookup;
 
@@ -26,19 +27,64 @@ public class IpAddressLookupHttpClient : IIpAddressLookupHttpClient
 
     public async Task<IpAddressLookupResponse> LookupIpAddressAsync(string ipAddress, CancellationToken ct)
     {
-        var response = await _httpClient.GetAsync($"{ipAddress}/json", ct);
-        if (response.IsSuccessStatusCode)
+        const int maxAttempts = 5;
+        var baseDelay = TimeSpan.FromMilliseconds(500);
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            var responseContent = await response.Content.ReadAsStringAsync(ct);
-            return JsonUtilities.DefaultDeserialize<IpAddressLookupResponse>(responseContent);
+            ct.ThrowIfCancellationRequested();
+
+            var response = await _httpClient.GetAsync($"{ipAddress}/json", ct);
+            if (response.IsSuccessStatusCode)
+            {
+                var responseContent = await response.Content.ReadAsStringAsync(ct);
+                return JsonUtilities.DefaultDeserialize<IpAddressLookupResponse>(responseContent);
+            }
+            
+            if (response.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable
+                && attempt < maxAttempts)
+            {
+                TimeSpan? retryDelay = null;
+
+                // The docs at https://ipapi.co/api/#errors say nothing of requests containing retry value headers.
+                // So, we will default to calculating our own reasonable retry delay.
+                retryDelay ??= CalculateRetryDelay(baseDelay, attempt);
+
+                var errorBody = await response.Content.ReadAsStringAsync(ct);
+                _logger.LogWarning(
+                    "Rate limited by ipapi.co for {ipAddress}. Attempt {attempt}/{maxAttempts}. Waiting {delay} before retry. Response: {response}",
+                    ipAddress,
+                    attempt,
+                    maxAttempts,
+                    retryDelay,
+                    errorBody);
+
+                await Task.Delay(retryDelay.Value, ct);
+                continue;
+            }
+            
+            var responseBody = await response.Content.ReadAsStringAsync(ct);
+            _logger.LogError(
+                "Unable to fetch IP address information for {ipAddress}. Response code: {responseCode}; Response: {response}.",
+                ipAddress,
+                response.StatusCode,
+                responseBody);
         }
 
-        _logger.LogError(
-            "Unable to fetch IP address information for {ipAddress}. Response code: {responseCode}; Response: {response}.",
-            ipAddress,
-            response.StatusCode,
-            await response.Content.ReadAsStringAsync(ct));
-
-        throw new Exception($"IP address lookup failed for {ipAddress}.");
+        throw new Exception($"IP address lookup failed for {ipAddress} after retries due to rate limiting.");
     }
+
+    private static TimeSpan CalculateRetryDelay(TimeSpan baseDelay, int attempt)
+    {
+        var backoff = TimeSpan.FromMilliseconds(baseDelay.TotalMilliseconds * Math.Pow(2, attempt - 1));
+        var jitterMs = Random.Shared.Next(0, 250);
+        var retryDelay = backoff + TimeSpan.FromMilliseconds(jitterMs);
+        
+        if (retryDelay > TimeSpan.FromSeconds(10))
+        {
+            retryDelay = TimeSpan.FromSeconds(10);
+        }
+        
+        return retryDelay;
+    } 
 }

--- a/src/Aquifer.Common/Clients/Http/IpAddressLookup/IpAddressLookupHttpClient.cs
+++ b/src/Aquifer.Common/Clients/Http/IpAddressLookup/IpAddressLookupHttpClient.cs
@@ -44,11 +44,9 @@ public class IpAddressLookupHttpClient : IIpAddressLookupHttpClient
             if (response.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable
                 && attempt < maxAttempts)
             {
-                TimeSpan? retryDelay = null;
-
                 // The docs at https://ipapi.co/api/#errors say nothing of requests containing retry value headers.
                 // So, we will default to calculating our own reasonable retry delay.
-                retryDelay ??= CalculateRetryDelay(baseDelay, attempt);
+                var retryDelay = CalculateRetryDelay(baseDelay, attempt);
 
                 var errorBody = await response.Content.ReadAsStringAsync(ct);
                 _logger.LogWarning(
@@ -59,7 +57,7 @@ public class IpAddressLookupHttpClient : IIpAddressLookupHttpClient
                     retryDelay,
                     errorBody);
 
-                await Task.Delay(retryDelay.Value, ct);
+                await Task.Delay(retryDelay, ct);
                 continue;
             }
             


### PR DESCRIPTION
This PR attempts to reduce the verbose and often excessive logging alerts when ip address lookups fail due to too many requests being sent by adding retry delay logic. 

Logging example:
> Unable to fetch IP address information for 105.112.218.79. Response code: TooManyRequests; Response: Too many rapid requests. Please try again in some time or signup for a paid plan at https://ipapi.co/pricing .